### PR TITLE
Add AdditionalPropertiesAttribute to Command Line Parsing

### DIFF
--- a/Development/Sources/TestApiCore/AcceptanceTests/CommandLineParsing/CommandLineParserTests.cs
+++ b/Development/Sources/TestApiCore/AcceptanceTests/CommandLineParsing/CommandLineParserTests.cs
@@ -4,6 +4,7 @@
 // All other rights reserved.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Test.CommandLineParsing;
 using Xunit;
 using Xunit.Extensions;
@@ -96,6 +97,29 @@ namespace Microsoft.Test.AcceptanceTests.CommandLineParsing
         }
 
         [Fact]
+        public void AdditionalPropertiesAttributeRequiresDictionary()
+        {
+            CommandLineArgumentsWithInvalidAdditionalProperties a = new CommandLineArgumentsWithInvalidAdditionalProperties();
+            string[] args = new string[] { "/Hello=World", "/Foo=Bar" };
+            Assert.Throws<ArgumentException>(delegate 
+            {
+                a.ParseArguments(args);
+            });
+        }
+
+        [Fact]
+        public void AdditionalPropertiesAttribute()
+        {
+            CommandLineArgumentsWithAdditionalProperties a = new CommandLineArgumentsWithAdditionalProperties();
+            string[] args = new string[] { "/Hello=World", "/Foo=Bar" };
+            a.ParseArguments(args);
+
+            Assert.Equal("World", a.Hello);
+            Assert.Equal(1, a.AdditionalProperties.Count);
+            Assert.Equal("Bar", a.AdditionalProperties["Foo"]);
+        }
+
+        [Fact]
         public void ExceptionWhenTryingToParseInProtectedFields()
         {
             CommandLineArgumentsWithProtectedFields a = new CommandLineArgumentsWithProtectedFields();
@@ -139,6 +163,20 @@ namespace Microsoft.Test.AcceptanceTests.CommandLineParsing
         {
             private bool? Verbose { get; set; }
             private int? RunId { get; set; }
+        }
+
+        protected class CommandLineArgumentsWithInvalidAdditionalProperties
+        {
+            [AdditionalProperties]
+            public System.Collections.Generic.Dictionary<string, object> AdditionalProperties { get; set; }
+        }
+
+        protected class CommandLineArgumentsWithAdditionalProperties
+        {
+            public string Hello { get; set; }
+
+            [AdditionalProperties]
+            public Dictionary<string, string> AdditionalProperties { get; set; }
         }
     }
 }

--- a/Development/Sources/TestApiCore/Code/CommandLineParsing/AdditionalPropertiesAttribute.cs
+++ b/Development/Sources/TestApiCore/Code/CommandLineParsing/AdditionalPropertiesAttribute.cs
@@ -1,0 +1,23 @@
+// (c) Copyright Microsoft Corporation.
+// This source is subject to the Microsoft Public License (Ms-PL).
+// Please see http://go.microsoft.com/fwlink/?LinkID=131993 for details.
+// All other rights reserved.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Test.CommandLineParsing
+{
+    /// <summary>
+    /// Defines whether a property value should contain all remaining properties which do not map to a named property in the object.
+    /// Only valid on types of Dictionary&lt;string, string&gt;.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+    public sealed class AdditionalPropertiesAttribute : Attribute
+    {
+        /// <summary />
+        public AdditionalPropertiesAttribute()
+        {
+        }
+    }
+}

--- a/Development/Sources/TestApiCore/Code/TestApiCore.csproj
+++ b/Development/Sources/TestApiCore/Code/TestApiCore.csproj
@@ -81,6 +81,7 @@
     <Compile Include="ApplicationControl\OutOfProcessApplicationSettings.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CommandLineParsing\AdditionalPropertiesAttribute.cs" />
     <Compile Include="CommandLineParsing\Command.cs" />
     <Compile Include="CommandLineParsing\CommandLineDictionary.cs" />
     <Compile Include="CommandLineParsing\CommandLineParser.cs" />
@@ -153,7 +154,7 @@
     <Compile Include="ObjectComparison\GraphNode.cs" />
     <Compile Include="ObjectComparison\GraphNodeTuple.cs" />
     <Compile Include="ObjectComparison\NamespaceDoc.cs" />
-    <None    Include="ObjectComparison\ObjectComparisonAPI.cd" />
+    <None Include="ObjectComparison\ObjectComparisonAPI.cd" />
     <Compile Include="ObjectComparison\ObjectComparisonMismatch.cs" />
     <Compile Include="ObjectComparison\ObjectComparisonMismatchType.cs" />
     <Compile Include="ObjectComparison\ObjectGraphCodec.cs" />


### PR DESCRIPTION
This change allows you to create a Dictionary<string, string> property on a command line arguments class and tag it with AdditionalProperties. Any command line parameters which do not match any of the other named properties will be put in this dictionary.

I specifically needed this because I have a program which logs events and the fields in the event can be passed in as Key/Value pairs.